### PR TITLE
csr matrix multiply in sum layer

### DIFF
--- a/experiments/nesy/torch_cpu_b128.log
+++ b/experiments/nesy/torch_cpu_b128.log
@@ -2,51 +2,51 @@
 ### Running sudoku_4 (batch size=128, device=cpu) ###
 Loaded SDD with 2408 nodes.
 Layerized in 2862 nodes and 31 layers
-  in 0.00126279s.
+  in 0.00122975s.
 Benchmarking Torch
-  to_torch           0.00123
+  to_torch           0.00154
   sparsity           0.00988
-  jit compile        1.09
-  forward (cold)     0.262
-  forward (warm)     0.00422 ± 6.15e-05
-   +backward (cold)  0.207
-   +backward (warm)  0.00659 ± 8.21e-05
+  jit compile        1.04
+  forward (cold)     0.0855
+  forward (warm)     0.00287 ± 0.000188
+   +backward (cold)  0.0489
+   +backward (warm)  0.0048 ± 0.000117
 
 ### Running 4-grid (batch size=128, device=cpu) ###
 Loaded SDD with 6610 nodes.
 Layerized in 5813 nodes and 25 layers
-  in 0.00306158s.
+  in 0.00314479s.
 Benchmarking Torch
-  to_torch           0.00136
+  to_torch           0.0017
   sparsity           0.00379
-  jit compile        0.00129
-  forward (cold)     0.0059
-  forward (warm)     0.00579 ± 0.000173
-   +backward (cold)  0.00983
-   +backward (warm)  0.00961 ± 7.94e-05
+  jit compile        0.00126
+  forward (cold)     0.0044
+  forward (warm)     0.00432 ± 0.000134
+   +backward (cold)  0.0075
+   +backward (warm)  0.00731 ± 8.5e-05
 
 ### Running seq_fun (batch size=128, device=cpu) ###
 Loaded SDD with 9730 nodes.
 Layerized in 20548 nodes and 85 layers
-  in 0.00687033s.
+  in 0.00675467s.
 Benchmarking Torch
-  to_torch           0.00415
+  to_torch           0.00505
   sparsity           0.00329
-  jit compile        0.00128
-  forward (cold)     0.0154
-  forward (warm)     0.0146 ± 8.41e-05
-   +backward (cold)  0.0235
-   +backward (warm)  0.0234 ± 0.000131
+  jit compile        0.00125
+  forward (cold)     0.0118
+  forward (warm)     0.0109 ± 8.37e-05
+   +backward (cold)  0.0183
+   +backward (warm)  0.0183 ± 0.000145
 
 ### Running warcraft_12 (batch size=128, device=cpu) ###
 Loaded SDD with 1110234 nodes.
 Layerized in 975417 nodes and 85 layers
-  in 1.34571s.
+  in 1.32688s.
 Benchmarking Torch
-  to_torch           0.0655
+  to_torch           0.0876
   sparsity           0.000132
-  jit compile        0.00138
-  forward (cold)     0.823
-  forward (warm)     0.86 ± 0.12
-   +backward (cold)  1.5
-   +backward (warm)  1.49 ± 0.0523
+  jit compile        0.00127
+  forward (cold)     0.702
+  forward (warm)     0.735 ± 0.086
+   +backward (cold)  1.32
+   +backward (warm)  1.3 ± 0.0738

--- a/experiments/nesy/torch_cuda_b128.log
+++ b/experiments/nesy/torch_cuda_b128.log
@@ -2,51 +2,51 @@
 ### Running sudoku_4 (batch size=128, device=cuda) ###
 Loaded SDD with 2408 nodes.
 Layerized in 2862 nodes and 31 layers
-  in 0.00300142s.
+  in 0.00157748s.
 Benchmarking Torch
-  to_torch           0.238
+  to_torch           0.332
   sparsity           0.00988
-  jit compile        3.87
-  forward (cold)     0.848
-  forward (warm)     0.00396 ± 0.000741
-   +backward (cold)  0.564
-   +backward (warm)  0.0102 ± 0.00212
+  jit compile        2.45
+  forward (cold)     0.453
+  forward (warm)     0.00317 ± 4.78e-05
+   +backward (cold)  0.326
+   +backward (warm)  0.0145 ± 0.00298
 
 ### Running 4-grid (batch size=128, device=cuda) ###
 Loaded SDD with 6610 nodes.
 Layerized in 5813 nodes and 25 layers
-  in 0.00619335s.
+  in 0.00486332s.
 Benchmarking Torch
-  to_torch           0.0148
+  to_torch           0.00598
   sparsity           0.00379
-  jit compile        0.00385
-  forward (cold)     0.00708
-  forward (warm)     0.00339 ± 0.00105
-   +backward (cold)  0.00966
-   +backward (warm)  0.0107 ± 0.00109
+  jit compile        0.00373
+  forward (cold)     0.00565
+  forward (warm)     0.00328 ± 0.000986
+   +backward (cold)  0.0147
+   +backward (warm)  0.015 ± 0.0011
 
 ### Running seq_fun (batch size=128, device=cuda) ###
 Loaded SDD with 9730 nodes.
 Layerized in 20548 nodes and 85 layers
-  in 0.0145401s.
+  in 0.0108875s.
 Benchmarking Torch
-  to_torch           0.0125
+  to_torch           0.0177
   sparsity           0.00329
-  jit compile        0.00348
-  forward (cold)     0.0134
-  forward (warm)     0.00725 ± 4.01e-05
-   +backward (cold)  0.0273
-   +backward (warm)  0.0324 ± 0.00495
+  jit compile        0.00349
+  forward (cold)     0.011
+  forward (warm)     0.00802 ± 1.93e-05
+   +backward (cold)  0.0466
+   +backward (warm)  0.0545 ± 0.00668
 
 ### Running warcraft_12 (batch size=128, device=cuda) ###
 Loaded SDD with 1110234 nodes.
 Layerized in 975417 nodes and 85 layers
-  in 1.46564s.
+  in 1.25214s.
 Benchmarking Torch
-  to_torch           0.139
+  to_torch           0.202
   sparsity           0.000132
-  jit compile        0.00281
-  forward (cold)     0.0125
-  forward (warm)     0.0166 ± 0.0065
-   +backward (cold)  0.103
-   +backward (warm)  0.102 ± 0.0116
+  jit compile        0.00222
+  forward (cold)     0.014
+  forward (warm)     0.0122 ± 1.31e-05
+   +backward (cold)  0.0764
+   +backward (warm)  0.0643 ± 0.00293

--- a/experiments/nesy/torch_mps_b128.log
+++ b/experiments/nesy/torch_mps_b128.log
@@ -2,51 +2,51 @@
 ### Running sudoku_4 (batch size=128, device=mps) ###
 Loaded SDD with 2408 nodes.
 Layerized in 2862 nodes and 31 layers
-  in 0.00129362s.
+  in 0.00123575s.
 Benchmarking Torch
-  to_torch           0.0236
+  to_torch           0.0349
   sparsity           0.00988
-  jit compile        1.05
-  forward (cold)     0.474
-  forward (warm)     0.0039 ± 0.000225
-   +backward (cold)  0.307
-   +backward (warm)  0.00693 ± 0.00037
+  jit compile        1.26
+  forward (cold)     0.879
+  forward (warm)     0.00483 ± 0.00148
+   +backward (cold)  0.331
+   +backward (warm)  0.00716 ± 0.000371
 
 ### Running 4-grid (batch size=128, device=mps) ###
 Loaded SDD with 6610 nodes.
 Layerized in 5813 nodes and 25 layers
-  in 0.00319075s.
+  in 0.00316917s.
 Benchmarking Torch
-  to_torch           0.0103
+  to_torch           0.0171
   sparsity           0.00379
-  jit compile        0.00127
-  forward (cold)     0.143
-  forward (warm)     0.00364 ± 0.00049
-   +backward (cold)  0.0708
-   +backward (warm)  0.00609 ± 0.000175
+  jit compile        0.0013
+  forward (cold)     0.14
+  forward (warm)     0.00349 ± 0.000103
+   +backward (cold)  0.0694
+   +backward (warm)  0.00616 ± 0.000223
 
 ### Running seq_fun (batch size=128, device=mps) ###
 Loaded SDD with 9730 nodes.
 Layerized in 20548 nodes and 85 layers
-  in 0.00698604s.
+  in 0.00784083s.
 Benchmarking Torch
-  to_torch           0.0334
+  to_torch           0.0599
   sparsity           0.00329
-  jit compile        0.00126
-  forward (cold)     0.666
-  forward (warm)     0.011 ± 0.000206
-   +backward (cold)  0.285
-   +backward (warm)  0.0201 ± 0.000312
+  jit compile        0.00138
+  forward (cold)     0.657
+  forward (warm)     0.011 ± 0.000329
+   +backward (cold)  0.28
+   +backward (warm)  0.0206 ± 0.000585
 
 ### Running warcraft_12 (batch size=128, device=mps) ###
 Loaded SDD with 1110234 nodes.
 Layerized in 975417 nodes and 85 layers
-  in 1.32286s.
+  in 1.34056s.
 Benchmarking Torch
-  to_torch           0.105
+  to_torch           0.149
   sparsity           0.000132
-  jit compile        0.00129
-  forward (cold)     1.12
-  forward (warm)     0.0154 ± 0.00127
-   +backward (cold)  0.844
-   +backward (warm)  0.422 ± 0.0152
+  jit compile        0.00131
+  forward (cold)     1.14
+  forward (warm)     0.0152 ± 0.000973
+   +backward (cold)  0.72
+   +backward (warm)  0.424 ± 0.0103

--- a/src/klay/jax/__init__.py
+++ b/src/klay/jax/__init__.py
@@ -1,8 +1,10 @@
 import numpy as np
 import jax
 import jax.numpy as jnp
+import jax.experimental.sparse as jsparse
 
 from klay.jax.semiring import get_semiring, encode_input
+from klay.jax.semiring.real import sum_layer as _plain_sum_layer
 
 
 def create_knowledge_layer(pointers, ix_outs, semiring):
@@ -12,15 +14,27 @@ def create_knowledge_layer(pointers, ix_outs, semiring):
     sum_layer, prod_layer = get_semiring(semiring)
     encoder = encode_input(semiring)
 
+    # Pre-build BCOO sparse matrices for layers using plain sum_layer (segment_sum).
+    # The loop is unrolled at JIT trace time, so Python-level dispatch is fine.
+    layers = []
+    for i, (ix_in, ix_out) in enumerate(zip(ixs_in, ixs_out)):
+        fn = prod_layer if i % 2 == 0 else sum_layer
+        if fn is _plain_sum_layer:
+            n_out = num_segments[i]
+            n_in = int(ix_in.max()) + 1
+            indices = np.stack([ix_out, ix_in], axis=1)
+            values = np.ones(len(ix_in), dtype=np.float32)
+            A = jsparse.BCOO((values, indices), shape=(n_out, n_in))
+            layers.append(lambda x, A=A, n_in=n_in: A @ x[:n_in])
+        else:
+            ns, ii, io = num_segments[i], ix_in, ix_out
+            layers.append(lambda x, fn=fn, ns=ns, ii=ii, io=io: fn(ns, ii, io, x))
 
     @jax.jit
     def wrapper(pos, neg=None):
         x = encoder(pos, neg)
-        for i, (ix_in, ix_out) in enumerate(zip(ixs_in, ixs_out)):
-            if i % 2 == 0:
-                x = prod_layer(num_segments[i], ix_in, ix_out, x)
-            else:
-                x = sum_layer(num_segments[i], ix_in, ix_out, x)
+        for layer in layers:
+            x = layer(x)
         return x
 
     return wrapper

--- a/src/klay/torch/layers.py
+++ b/src/klay/torch/layers.py
@@ -43,8 +43,25 @@ class CircuitLayer(nn.Module):
 
 
 class SumLayer(CircuitLayer):
+    def __init__(self, ix_in, ix_out, eps):
+        super().__init__(ix_in, ix_out, eps)
+        values = torch.ones(len(ix_in), dtype=torch.float32)
+        self._weight = torch.sparse_coo_tensor(
+            torch.stack([ix_out, ix_in]), values, size=(self.out_shape[0], self.in_shape[0])
+        ).to_sparse_csr()
+
+    def _apply(self, fn, *args, **kwargs):
+        result = super()._apply(fn, *args, **kwargs)
+        try:
+            self._weight = fn(self._weight)
+        except (NotImplementedError, RuntimeError):
+            pass  # keep on CPU if device doesn't support sparse CSR (e.g. MPS)
+        return result
+
     def forward(self, x):
-        return self._scatter_forward(x[self.ix_in], "sum")
+        if x.device.type == 'mps':
+            return self._scatter_forward(x[self.ix_in], "sum")
+        return self._weight @ x[:self.in_shape[0]]
 
 
 class ProdLayer(CircuitLayer):


### PR DESCRIPTION
- sum layer can be formulated as sparse matrix multiply.
- gives small (10% - 20%) speedup.
- sparse matrix multiply doesn't work on MPS in torch, so there the old scatter reduce is used.