### PR TITLE
ref: encapsulate classes in klay namespace

### DIFF
--- a/include/klay/circuit.h
+++ b/include/klay/circuit.h
@@ -10,6 +10,8 @@
 #include "node.h"
 #include "hash_set8.hpp"
 
+namespace klay {
+
 class NodePtr {
 public:
     NodePtr(Node* ptr) : ptr(ptr) { }
@@ -216,3 +218,5 @@ public:
         return NodePtr(add_node_level_compressed(node));
     }
 };
+
+}  // namespace klay

--- a/include/klay/indices.h
+++ b/include/klay/indices.h
@@ -12,6 +12,7 @@
 
 namespace nb = nanobind;
 using namespace nb::literals;
+using namespace klay;
 
 using Array = nb::ndarray<nb::numpy, long int, nb::shape<-1>>;
 using Arrays = std::vector<Array>;

--- a/include/klay/literal.h
+++ b/include/klay/literal.h
@@ -3,6 +3,8 @@
 #include <iostream>
 using namespace std;
 
+namespace klay {
+
 typedef int Var;
 
 /**
@@ -66,3 +68,5 @@ public:
 Lit Lit::fromInt(int i) {
     return Lit(std::abs(i), i < 0);
 }
+
+}  // namespace klay

--- a/include/klay/node.h
+++ b/include/klay/node.h
@@ -10,6 +10,8 @@
 
 #include "cassert"
 
+namespace klay {
+
 enum class NodeType {True, False, Or, And, Leaf};
 
 
@@ -127,3 +129,4 @@ struct NodeEqual {
 };
 
 
+}  // namespace klay

--- a/src/circuit.cpp
+++ b/src/circuit.cpp
@@ -1,6 +1,8 @@
 #include "klay/circuit.h"
 #include "cassert"
 
+using namespace klay;
+
 Node* Circuit::add_node(Node* node) {
     if (layers.size() <= node->layer)
         layers.resize(node->layer + 1);

--- a/src/indices.cpp
+++ b/src/indices.cpp
@@ -1,6 +1,8 @@
 #include <klay/indices.h>
 #include <klay/circuit.h>
 
+using namespace klay;
+
 void cleanup(void* data) noexcept {
   delete[] static_cast<long int*>(data);
 }

--- a/src/klay_bindings.cpp
+++ b/src/klay_bindings.cpp
@@ -8,6 +8,7 @@
 #include "klay/circuit.h"
 #include "klay/indices.h"
 
+using namespace klay;
 namespace nb = nanobind;
 using namespace nb::literals;
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1,5 +1,7 @@
 #include "klay/node.h"
 
+using namespace klay;
+
 /**
  * Improve bit dispersion of a given hash value h.
  */


### PR DESCRIPTION
fixes #28 

- Wrap Node, Circuit, Lit, etc. in the klay namespace.
- Prevents global namespace pollution.